### PR TITLE
Faster testing code

### DIFF
--- a/bilm/training.py
+++ b/bilm/training.py
@@ -461,7 +461,7 @@ class LanguageModel(object):
             # softmax_W is just the embedding layer
             self.softmax_W = self.embedding_weights
 
-        with tf.variable_scope('softmax'), tf.device('/cpu:0'):
+        with tf.variable_scope('softmax'):
             # Glorit init (std=(1.0 / sqrt(fan_in))
             softmax_init = tf.random_normal_initializer(0.0,
                 1.0 / np.sqrt(softmax_dim))
@@ -502,10 +502,10 @@ class LanguageModel(object):
 
                 else:
                     # get the full softmax loss
-                    output_scores = tf.matmul(
-                        lstm_output_flat,
-                        tf.transpose(self.softmax_W)
-                    ) + self.softmax_b
+                    output_scores = tf.transpose(tf.matmul(
+                        self.softmax_W, 
+                        tf.transpose(lstm_output_flat)
+                    )) + self.softmax_b
                     # NOTE: tf.nn.sparse_softmax_cross_entropy_with_logits
                     #   expects unnormalized output since it performs the
                     #   softmax internally


### PR DESCRIPTION
* Creating the softmax_W tensor on CPU makes it transfer the tensor from CPU to GPU for every batch during test time (where full softmax is used), slowing down the code by 5x or so. 
* Transposing softmax_W is a large operation compared to transposing input and output vectors, increasing the speed of full softmax further

By profiling using timeline from Tensorflow we observe the following
*Before* - 
<img width="1440" alt="screen shot 2018-05-16 at 2 22 54 pm" src="https://user-images.githubusercontent.com/1595936/40144992-1d6d8010-5915-11e8-93e3-29d27aa0ac3b.png">
*After* - 
<img width="1435" alt="screen shot 2018-05-16 at 2 26 56 pm" src="https://user-images.githubusercontent.com/1595936/40145033-3d72686c-5915-11e8-92e5-5dca6c305033.png">
The big MEMCPYHtoD and big Transpose before MatMul are gone
