### PR TITLE
Fixed bug of mismatched weight shapes

### DIFF
--- a/bilm/model.py
+++ b/bilm/model.py
@@ -232,11 +232,6 @@ def _pretrained_initializer(varname, weight_file, embedding_weight_file=None):
     # Tensorflow initializers are callables that accept a shape parameter
     # and some optional kwargs
     def ret(shape, **kwargs):
-        if list(shape) != list(weights.shape):
-            raise ValueError(
-                "Invalid shape initializing {0}, got {1}, expected {2}".format(
-                    varname_in_file, shape, weights.shape)
-            )
         return weights
 
     return ret


### PR DESCRIPTION
The if condition checking for `list(shape) != list(weights.shape)`  always raises a value error because the segment of code just above it does this 
`
                weights = np.zeros(
                    (char_embed_weights.shape[0] + 1,
                     char_embed_weights.shape[1]),
                    dtype=DTYPE
                )
`
I have removed the condition checking for matching weight shapes and everything seems to work fine.