### PR TITLE
Remove for loop scope leak

### DIFF
--- a/bilm/data.py
+++ b/bilm/data.py
@@ -164,7 +164,7 @@ class UnicodeCharsVocabulary(Vocabulary):
         code[0] = self.bow_char
         for k, chr_id in enumerate(word_encoded, start=1):
             code[k] = chr_id
-        code[k + 1] = self.eow_char
+        code[len(word_encoded) + 1] = self.eow_char
 
         return code
 


### PR DESCRIPTION
Python 3.6 does not allow leaking loop variables outside the scope of the loop. This change removes this behaviour, allowing the program to run under Python3.6+.