### PR TITLE
Add optional max_length arg in batch_sentences

### DIFF
--- a/bilm/data.py
+++ b/bilm/data.py
@@ -205,14 +205,17 @@ class Batcher(object):
         )
         self._max_token_length = max_token_length
 
-    def batch_sentences(self, sentences: List[List[str]]):
+    def batch_sentences(self, sentences: List[List[str]], max_length=None):
         '''
         Batch the sentences as character ids
         Each sentence is a list of tokens without <s> or </s>, e.g.
         [['The', 'first', 'sentence', '.'], ['Second', '.']]
         '''
         n_sentences = len(sentences)
-        max_length = max(len(sentence) for sentence in sentences) + 2
+        if max_length == None:
+            max_length = max(len(sentence) for sentence in sentences) + 2
+        else:
+            max_length += 2
 
         X_char_ids = np.zeros(
             (n_sentences, max_length, self._max_token_length),
@@ -240,14 +243,17 @@ class TokenBatcher(object):
         '''
         self._lm_vocab = Vocabulary(lm_vocab_file)
 
-    def batch_sentences(self, sentences: List[List[str]]):
+    def batch_sentences(self, sentences: List[List[str]], max_length=None):
         '''
         Batch the sentences as character ids
         Each sentence is a list of tokens without <s> or </s>, e.g.
         [['The', 'first', 'sentence', '.'], ['Second', '.']]
         '''
         n_sentences = len(sentences)
-        max_length = max(len(sentence) for sentence in sentences) + 2
+        if max_length == None:
+            max_length = max(len(sentence) for sentence in sentences) + 2
+        else:
+            max_length += 2
 
         X_ids = np.zeros((n_sentences, max_length), dtype=np.int64)
 

--- a/bilm/training.py
+++ b/bilm/training.py
@@ -11,6 +11,7 @@ import tensorflow as tf
 import numpy as np
 
 from tensorflow.python.ops.init_ops import glorot_uniform_initializer
+from tqdm import tqdm
 
 from .data import Vocabulary, UnicodeCharsVocabulary, InvalidNumberOfCharacters
 
@@ -835,6 +836,7 @@ def train(options, data, n_gpus, tf_save_dir, tf_log_dir,
 
         t1 = time.time()
         data_gen = data.iter_batches(batch_size * n_gpus, unroll_steps)
+        pbar = tqdm(total=n_batches_total)
         for batch_no, batch in enumerate(data_gen, start=1):
 
             # slice the input in the batch for the feed_dict
@@ -893,7 +895,9 @@ def train(options, data, n_gpus, tf_save_dir, tf_log_dir,
 
             if batch_no == n_batches_total:
                 # done training!
+                pbar.close()
                 break
+            pbar.update(1)
 
 
 def clip_by_global_norm_summary(t_list, clip_norm, norm_name, variables):


### PR DESCRIPTION
This allows integration into downstream tasks with an existing placeholder size. Without `max_length`, `batch_sentences` would calculate it based on the longest sentence in the batch, but sometimes the output should match another specified size.